### PR TITLE
Remove dependency on puppetlabs-resource_api

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,10 +9,6 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 3.2.0 < 8.0.0"
-    },
-    {
-      "name": "puppetlabs/resource_api",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
puppetlabs-resource_api module is deprecated.
The resource_api gem is now included since puppet 6.